### PR TITLE
Add static life calendar page

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Календарь жизни</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="lifecalendar/lifecalendar.css">
+</head>
+<body>
+  <div class="container">
+    <h1 class="title">КАЛЕНДАРЬ ЖИЗНИ</h1>
+    <h2 class="subtitle">Время ограничено и ценно, как ты хочешь его провести?</h2>
+    <div class="calendar-container">
+      <div id="calendar" class="calendar"></div>
+      <div class="life-stages">
+        <div class="life-stage childhood" style="color:#2acdf1">Детство (0–12 лет)</div>
+        <div class="life-stage teenage" style="color:#f87a40">Подростки (13–19 лет)</div>
+        <div class="life-stage early" style="color:#ff4fe8">Ранняя взрослость (20–34 лет)</div>
+        <div class="life-stage mid" style="color:#1af041">Средняя взрослость (35–49 лет)</div>
+        <div class="life-stage mature" style="color:#f5aa1f">Зрелая взрослость (50–79 лет)</div>
+        <div class="life-stage late" style="color:#db61b0">Поздняя взрослость (80–100 лет)</div>
+      </div>
+    </div>
+  </div>
+  <script src="lifecalendar/lifecalendar.js"></script>
+</body>
+</html>

--- a/lifecalendar/lifecalendar.css
+++ b/lifecalendar/lifecalendar.css
@@ -1,0 +1,81 @@
+body {
+  font-family: 'Inter', sans-serif;
+  text-transform: uppercase;
+  margin: 0;
+  padding: 0;
+  overflow-y: scroll;
+}
+
+.container {
+  max-width: 936px;
+  margin: 0 auto;
+  margin-bottom: 30px;
+  text-align: center;
+}
+
+.title {
+  font-size: 72px;
+  font-weight: 900;
+  margin-top: 30px;
+}
+
+.subtitle {
+  font-size: 12px;
+  font-weight: 800;
+  margin-top: 15px;
+}
+
+.calendar-container {
+  display: flex;
+  justify-content: center;
+  position: relative;
+}
+
+.calendar {
+  display: flex;
+  flex-direction: column;
+  padding-left: 30px;
+}
+
+.year-row {
+  display: flex;
+  margin-top: 2px;
+  position: relative;
+}
+
+.year-label {
+  position: absolute;
+  left: -25px;
+  width: 17.7px;
+  font-size: 9px;
+  font-weight: 900;
+  text-align: center;
+}
+
+.circle {
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  border: 1px solid #000;
+  margin-right: 2px;
+  box-sizing: border-box;
+}
+
+.life-stages {
+  display: flex;
+  flex-direction: column;
+  width: 30px;
+}
+
+.life-stage {
+  font-weight: 700;
+  font-size: 9px;
+  transform: rotate(90deg);
+}
+
+.life-stage.childhood { margin-top: 110px; margin-left:-50px; width:120px; }
+.life-stage.teenage   { margin-top: 165px; margin-left:-63px; width:150px; }
+.life-stage.early     { margin-top: 170px; margin-left:-76px; width:175px; }
+.life-stage.mid       { margin-top: 240px; margin-left:-76px; width:175px; }
+.life-stage.mature    { margin-top: 365px; margin-left:-76px; width:175px; }
+.life-stage.late      { margin-top: 430px; margin-left:-76px; width:175px; }

--- a/lifecalendar/lifecalendar.js
+++ b/lifecalendar/lifecalendar.js
@@ -1,0 +1,53 @@
+function yearToColor(year) {
+  if (year <= 12) return '#2acdf1';
+  if (year <= 19) return '#f87a40';
+  if (year <= 34) return '#ff4fe8';
+  if (year <= 49) return '#1af041';
+  if (year <= 79) return '#f5aa1f';
+  if (year <= 100) return '#db61b0';
+  return '#000000';
+}
+
+function getBirthDate() {
+  const params = new URLSearchParams(window.location.search);
+  const y = params.get('year');
+  const m = params.get('month');
+  const d = params.get('day');
+  if (y && m && d) {
+    return new Date(Number(y), Number(m) - 1, Number(d));
+  }
+  // Change birthdate here if needed
+  return new Date('2004-01-19');
+}
+
+function weeksSince(date) {
+  const seconds = (Date.now() - date.getTime()) / 1000;
+  return Math.round(seconds / (60 * 60 * 24 * 7));
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const birthDate = getBirthDate();
+  const livedWeeks = weeksSince(birthDate);
+  const container = document.getElementById('calendar');
+  const weeksInYear = 52;
+
+  for (let year = 0; year <= 100; year++) {
+    const row = document.createElement('div');
+    row.className = 'year-row';
+    const label = document.createElement('div');
+    label.className = 'year-label';
+    label.textContent = year;
+    row.appendChild(label);
+    const color = yearToColor(year);
+    for (let week = 0; week < weeksInYear; week++) {
+      const circle = document.createElement('span');
+      circle.className = 'circle';
+      circle.style.borderColor = color;
+      if (year * weeksInYear + week < livedWeeks) {
+        circle.style.backgroundColor = color + '66';
+      }
+      row.appendChild(circle);
+    }
+    container.appendChild(row);
+  }
+});


### PR DESCRIPTION
## Summary
- add static `calendar.html` with grid of weeks
- include supporting JavaScript and CSS in new `lifecalendar` directory

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6867a707fab08330a399a5b6a30e5b60