### PR TITLE
Add static life calendar page

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Календарь жизни</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="lifecalendar/lifecalendar.css">
+</head>
+<body>
+  <div class="container">
+    <h1 class="title">КАЛЕНДАРЬ ЖИЗНИ</h1>
+    <h2 class="subtitle">Время ограничено и ценно, как ты хочешь его провести?</h2>
+    <div class="calendar-container">
+      <div id="calendar" class="calendar"></div>
+      <div class="life-stages">
+        <div class="life-stage stage-early-childhood" style="color:#A3A380">Раннее детство (0–6 лет)</div>
+        <div class="life-stage stage-school" style="color:#C0B887">Школьные годы (7–18 лет)</div>
+        <div class="life-stage stage-university" style="color:#D7CE93">Высшее образование (19–24 лет)</div>
+        <div class="life-stage stage-adult" style="color:#E8D9B5">Взрослая жизнь (25–45 лет)</div>
+        <div class="life-stage stage-middle" style="color:#EFEBCE">Средний возраст (46–59 лет)</div>
+        <div class="life-stage stage-senior" style="color:#D8A48F">Пожилой возраст (60–89 лет)</div>
+        <div class="life-stage stage-old" style="color:#BB8588">Возраст долгожителей (90–100 лет)</div>
+      </div>
+    </div>
+  </div>
+  <script src="lifecalendar/lifecalendar.js"></script>
+</body>
+</html>

--- a/lifecalendar/lifecalendar.css
+++ b/lifecalendar/lifecalendar.css
@@ -1,0 +1,82 @@
+body {
+  font-family: 'Inter', sans-serif;
+  text-transform: uppercase;
+  margin: 0;
+  padding: 0;
+  overflow-y: scroll;
+}
+
+.container {
+  max-width: 936px;
+  margin: 0 auto;
+  margin-bottom: 30px;
+  text-align: center;
+}
+
+.title {
+  font-size: 72px;
+  font-weight: 900;
+  margin-top: 30px;
+}
+
+.subtitle {
+  font-size: 12px;
+  font-weight: 800;
+  margin-top: 15px;
+}
+
+.calendar-container {
+  display: flex;
+  justify-content: center;
+  position: relative;
+}
+
+.calendar {
+  display: flex;
+  flex-direction: column;
+  padding-left: 30px;
+}
+
+.year-row {
+  display: flex;
+  margin-top: 2px;
+  position: relative;
+}
+
+.year-label {
+  position: absolute;
+  left: -25px;
+  width: 17.7px;
+  font-size: 9px;
+  font-weight: 900;
+  text-align: center;
+}
+
+.circle {
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  border: 1px solid #000;
+  margin-right: 2px;
+  box-sizing: border-box;
+}
+
+.life-stages {
+  display: flex;
+  flex-direction: column;
+  width: 30px;
+}
+
+.life-stage {
+  font-weight: 700;
+  font-size: 9px;
+  transform: rotate(90deg);
+}
+
+.stage-early-childhood { margin-top: 90px;  margin-left:-55px; width:130px; }
+.stage-school         { margin-top: 140px; margin-left:-70px; width:160px; }
+.stage-university     { margin-top: 185px; margin-left:-70px; width:160px; }
+.stage-adult          { margin-top: 260px; margin-left:-76px; width:175px; }
+.stage-middle         { margin-top: 345px; margin-left:-76px; width:175px; }
+.stage-senior         { margin-top: 430px; margin-left:-76px; width:175px; }
+.stage-old            { margin-top: 505px; margin-left:-76px; width:175px; }

--- a/lifecalendar/lifecalendar.js
+++ b/lifecalendar/lifecalendar.js
@@ -1,0 +1,87 @@
+// Compute color per life stage with Russian labels
+const STAGE_COLORS = [
+  '#A3A380', // раннее детство
+  '#C0B887', // школьные годы
+  '#D7CE93', // высшее образование
+  '#E8D9B5', // взрослая жизнь
+  '#EFEBCE', // средний возраст
+  '#D8A48F', // пожилой возраст
+  '#BB8588'  // возраст долгожителей
+];
+
+function getBirthDate() {
+  const params = new URLSearchParams(window.location.search);
+  const y = params.get('year');
+  const m = params.get('month');
+  const d = params.get('day');
+  if (y && m && d) {
+    return new Date(Number(y), Number(m) - 1, Number(d));
+  }
+  // Change birthdate here if needed
+  return new Date('2004-01-19');
+}
+
+function weeksSince(date) {
+  const seconds = (Date.now() - date.getTime()) / 1000;
+  return Math.round(seconds / (60 * 60 * 24 * 7));
+}
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+const YEAR_MS = 365.25 * 24 * 60 * 60 * 1000;
+
+function stageForDate(date, birth) {
+  const baseY = birth.getFullYear();
+  const earlyEnd = new Date(baseY + 7, 8, 1);            // 1 Sep after 7th bday
+  const schoolEnd = new Date(baseY + 18, 5, 20);         // 20 Jun after 18th
+  const uniStart = new Date(baseY + 19, 8, 1);           // 1 Sep after 19th
+  const uniEnd = new Date(baseY + 24, 5, 20);            // 20 Jun after 24th
+  const adultEnd = new Date(baseY + 45, birth.getMonth(), birth.getDate());
+  const midEnd = new Date(baseY + 59, birth.getMonth(), birth.getDate());
+  const seniorEnd = new Date(baseY + 89, birth.getMonth(), birth.getDate());
+
+  if (date < earlyEnd) return 0;                         // 0-6
+  if (date >= earlyEnd && date <= schoolEnd) return 1;   // 7-18
+  if (date >= uniStart && date <= uniEnd) return 2;      // 19-24
+  if (date < adultEnd) return 3;                         // 25-45
+  if (date < midEnd) return 4;                           // 46-59
+  if (date < seniorEnd) return 5;                        // 60-89
+  return 6;                                              // 90-100
+}
+
+function colorForStage(stage, lived) {
+  const c = STAGE_COLORS[stage] || '#000000';
+  if (lived) return c;
+  // add low opacity for future weeks
+  return c + '33';
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const birthDate = getBirthDate();
+  const livedWeeks = weeksSince(birthDate);
+  const container = document.getElementById('calendar');
+  const weeksInYear = 52;
+
+  for (let year = 0; year <= 100; year++) {
+    const row = document.createElement('div');
+    row.className = 'year-row';
+    const label = document.createElement('div');
+    label.className = 'year-label';
+    label.textContent = year;
+    row.appendChild(label);
+    for (let week = 0; week < weeksInYear; week++) {
+      const index = year * weeksInYear + week;
+      const date = new Date(birthDate.getTime() + index * WEEK_MS);
+      const stage = stageForDate(date, birthDate);
+      const lived = index < livedWeeks;
+      const circle = document.createElement('span');
+      circle.className = 'circle';
+      const color = colorForStage(stage, lived);
+      circle.style.borderColor = color;
+      if (lived) {
+        circle.style.backgroundColor = color;
+      }
+      row.appendChild(circle);
+    }
+    container.appendChild(row);
+  }
+});


### PR DESCRIPTION
## Summary
- add static `calendar.html` with grid of weeks
- include supporting JavaScript and CSS in new `lifecalendar` directory
- refine life stages, intervals and color scheme

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6867a707fab08330a399a5b6a30e5b60