### PR TITLE
Refine age stages and colors

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -15,13 +15,13 @@
     <div class="calendar-container">
       <div id="calendar" class="calendar"></div>
       <div class="life-stages">
-        <div class="life-stage stage-early-childhood" style="color:#A3A380">Раннее детство (0–6 лет)</div>
-        <div class="life-stage stage-school" style="color:#C0B887">Школьные годы (7–18 лет)</div>
-        <div class="life-stage stage-university" style="color:#D7CE93">Высшее образование (19–24 лет)</div>
-        <div class="life-stage stage-adult" style="color:#E8D9B5">Взрослая жизнь (25–45 лет)</div>
-        <div class="life-stage stage-middle" style="color:#EFEBCE">Средний возраст (46–59 лет)</div>
-        <div class="life-stage stage-senior" style="color:#D8A48F">Пожилой возраст (60–89 лет)</div>
-        <div class="life-stage stage-old" style="color:#BB8588">Возраст долгожителей (90–100 лет)</div>
+        <div class="life-stage stage-early-childhood" style="color:#b0e0e6">Раннее детство (0–6 лет)</div>
+        <div class="life-stage stage-school" style="color:#87ceeb">Школьные годы (7–18 лет)</div>
+        <div class="life-stage stage-university" style="color:#5dade2">Высшее образование (19–24 лет)</div>
+        <div class="life-stage stage-adult" style="color:#48c9b0">Взрослая жизнь (25–45 лет)</div>
+        <div class="life-stage stage-middle" style="color:#1abc9c">Средний возраст (46–59 лет)</div>
+        <div class="life-stage stage-senior" style="color:#148f77">Пожилой возраст (60–89 лет)</div>
+        <div class="life-stage stage-old" style="color:#0e6251">Возраст долгожителей (90–100 лет)</div>
       </div>
     </div>
   </div>

--- a/lifecalendar/lifecalendar.css
+++ b/lifecalendar/lifecalendar.css
@@ -73,10 +73,10 @@ body {
   transform: rotate(90deg);
 }
 
-.stage-early-childhood { margin-top: 90px;  margin-left:-55px; width:130px; }
-.stage-school         { margin-top: 140px; margin-left:-70px; width:160px; }
-.stage-university     { margin-top: 185px; margin-left:-70px; width:160px; }
-.stage-adult          { margin-top: 260px; margin-left:-76px; width:175px; }
-.stage-middle         { margin-top: 345px; margin-left:-76px; width:175px; }
-.stage-senior         { margin-top: 430px; margin-left:-76px; width:175px; }
-.stage-old            { margin-top: 505px; margin-left:-76px; width:175px; }
+.stage-early-childhood { margin-left:-55px; width:130px; }
+.stage-school         { margin-left:-70px; width:160px; }
+.stage-university     { margin-left:-70px; width:160px; }
+.stage-adult          { margin-left:-76px; width:175px; }
+.stage-middle         { margin-left:-76px; width:175px; }
+.stage-senior         { margin-left:-76px; width:175px; }
+.stage-old            { margin-left:-76px; width:175px; }

--- a/lifecalendar/lifecalendar.js
+++ b/lifecalendar/lifecalendar.js
@@ -1,12 +1,12 @@
 // Compute color per life stage with Russian labels
 const STAGE_COLORS = [
-  '#A3A380', // раннее детство
-  '#C0B887', // школьные годы
-  '#D7CE93', // высшее образование
-  '#E8D9B5', // взрослая жизнь
-  '#EFEBCE', // средний возраст
-  '#D8A48F', // пожилой возраст
-  '#BB8588'  // возраст долгожителей
+  '#b0e0e6', // раннее детство
+  '#87ceeb', // школьные годы
+  '#5dade2', // высшее образование
+  '#48c9b0', // взрослая жизнь
+  '#1abc9c', // средний возраст
+  '#148f77', // пожилой возраст
+  '#0e6251'  // возраст долгожителей
 ];
 
 function getBirthDate() {
@@ -55,6 +55,41 @@ function colorForStage(stage, lived) {
   return c + '33';
 }
 
+function setStageLabelPositions(birth) {
+  const circleEl = document.querySelector('.circle');
+  const rowEl = document.querySelector('.year-row');
+  if (!circleEl || !rowEl) return;
+
+  const circleSize = parseFloat(getComputedStyle(circleEl).height);
+  const rowMargin = parseFloat(getComputedStyle(rowEl).marginTop);
+  const rowHeight = circleSize + rowMargin;
+
+  const baseY = birth.getFullYear();
+  const earlyEnd = new Date(baseY + 7, 8, 1);
+  const schoolEnd = new Date(baseY + 18, 5, 20);
+  const uniStart = new Date(baseY + 19, 8, 1);
+  const uniEnd = new Date(baseY + 24, 5, 20);
+  const adultEnd = new Date(baseY + 45, birth.getMonth(), birth.getDate());
+  const midEnd = new Date(baseY + 59, birth.getMonth(), birth.getDate());
+  const seniorEnd = new Date(baseY + 89, birth.getMonth(), birth.getDate());
+
+  const week = (d) => Math.round((d.getTime() - birth.getTime()) / WEEK_MS);
+
+  const positions = [
+    week(earlyEnd) / 2,
+    (week(schoolEnd) + week(earlyEnd)) / 2,
+    (week(uniEnd) + week(uniStart)) / 2,
+    (week(adultEnd) + week(uniEnd)) / 2,
+    (week(midEnd) + week(adultEnd)) / 2,
+    (week(seniorEnd) + week(midEnd)) / 2,
+    (5200 + week(seniorEnd)) / 2,
+  ];
+
+  document.querySelectorAll('.life-stage').forEach((el, idx) => {
+    el.style.marginTop = `${(positions[idx] / 52) * rowHeight}px`;
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const birthDate = getBirthDate();
   const livedWeeks = weeksSince(birthDate);
@@ -84,4 +119,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     container.appendChild(row);
   }
+
+  setStageLabelPositions(birthDate);
 });


### PR DESCRIPTION
## Summary
- update stage colors to blue/green palette
- position sidebar labels dynamically according to the life stages
- clean up css margins for stage labels

## Testing
- `ls calendar/out >/dev/null 2>&1 && echo "out exists" || echo "out not built"`

------
https://chatgpt.com/codex/tasks/task_e_6867c8b2b25083308116df15512aecfe