### PR TITLE
Fix decryption crash and async error handling

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -30,9 +30,10 @@ async def cancel(update: Update, context: ContextTypes. DEFAULT_TYPE):
     await update.message.reply_text('Хорошо, если передумаешь — я всегда тут')
     return ConversationHandler.END
 
-def error_handler(update, context):
+async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE):
     if isinstance(context.error, telegram.error.Forbidden):
         return
+    print(f'Unhandled error: {context.error}')
 
 def main():
     application = (

--- a/handlers/handle_start.py
+++ b/handlers/handle_start.py
@@ -231,8 +231,15 @@ async def ask_dates(update: Update, context: ContextTypes.DEFAULT_TYPE):
     query = update.callback_query 
     await query.answer()
     answer = query.data
-    user_data = await get_user_data(update.effective_user.id) 
-    gender = user_data['gender']
+    user_data = await get_user_data(update.effective_user.id)
+    gender = user_data.get('gender')
+    if not gender:
+        await context.bot.send_message(
+            chat_id    = update.effective_chat.id,
+            text       = 'Упс, не получилось получить твои данные. Давай начнём заново: нажми /start',
+            parse_mode = 'Markdown',
+        )
+        return ConversationHandler.END
 
     await context.bot.delete_message(
         chat_id = query.message.chat.id,


### PR DESCRIPTION
## Summary
- prevent crash in `ask_dates` when user data is corrupted
- make `get_user_data` robust against decryption errors
- convert `error_handler` to async for Telegram bot

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687fa7c6509c8330999c2df5126c719d