### PR TITLE
Refactor date parsing

### DIFF
--- a/handlers/handle_start.py
+++ b/handlers/handle_start.py
@@ -6,6 +6,7 @@ from dotenv import load_dotenv
 from utils.typing import _keep_typing
 from life_calendar import create_calendar
 import asyncio, random, os, secrets, re, warnings
+from utils.dateparser import parse_dates
 from utils.dbtools import set_birth, set_name, set_gender, get_user_data, set_empty_event, get_events, set_event, user_exists, delete_data
 warnings.filterwarnings('ignore')
 load_dotenv()
@@ -310,34 +311,20 @@ async def create_second_calendar(update: Update, context: ContextTypes.DEFAULT_T
                     parse_mode   = 'Markdown', 
                 ) 
                 return ASK_DATE
-    else: 
-        if event_type == 'Курение': 
-            try: 
-                dates = list(map(int, re.findall(r'\d+', answer)))
-            except: 
-                await context.bot.send_message(
-                    chat_id      = update.effective_chat.id,
-                    text         = 'Не могу прочитать твой текст😔 Напиши возраст еще раз, в формате «С 16 лет» или «С 16 до 23 лет»', 
-                    parse_mode   = 'Markdown', 
-                )
-                return ASK_DATE
-        else: 
-            try: 
-                dates = list(map(int, re.findall(r'\d+', answer)))
-            except: 
-                await context.bot.send_message(
-                    chat_id      = update.effective_chat.id,
-                    text         = 'Не могу прочитать твой текст😔 Напиши возраст еще раз, в формате «С 16 лет» или «С 16 до 49 лет»', 
-                    parse_mode   = 'Markdown', 
-                )
-                return ASK_DATE
-        if len(dates) == 1: 
-            event = date(year + dates[0] + ((month, day) > (8, 31)), 1, 1)
-        else: 
-            start, end = sorted(dates)
-            start = date(year + start + ((month, day) > (8, 31)), 1, 7)
-            end   = date(year + end + ((month, day) > (8, 31)), 12, 31)
-            event = (start, end)
+    else:
+        try:
+            event = parse_dates(answer, date(year, month, day))
+        except ValueError:
+            if event_type == 'Курение':
+                text_error = 'Не могу прочитать твой текст😔 Напиши возраст еще раз, в формате «С 16 лет» или «С 16 до 23 лет»'
+            else:
+                text_error = 'Не могу прочитать твой текст😔 Напиши возраст еще раз, в формате «С 16 лет» или «С 16 до 49 лет»'
+            await context.bot.send_message(
+                chat_id      = update.effective_chat.id,
+                text         = text_error,
+                parse_mode   = 'Markdown',
+            )
+            return ASK_DATE
 
     await set_event(update.effective_user.id, event_type, event)
     

--- a/utils/dateparser.py
+++ b/utils/dateparser.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import re
+from datetime import date
+
+# month names in english and russian to detect textual months
+_MONTH_WORDS = [
+    'january', 'february', 'march', 'april', 'may', 'june', 'july',
+    'august', 'september', 'october', 'november', 'december',
+    'январ', 'феврал', 'март', 'апрел', 'май', 'июн', 'июл',
+    'август', 'сентябр', 'октябр', 'ноябр', 'декабр'
+]
+
+_MONTH_RE = re.compile(r'(?:' + '|'.join(_MONTH_WORDS) + r')', re.IGNORECASE)
+_DECIMAL_RE = re.compile(r'\b\d+\.\d+(?!\.)')
+
+__all__ = ['parse_dates']
+
+def _contains_text_month(text: str) -> bool:
+    return bool(_MONTH_RE.search(text))
+
+def _contains_decimal_age(text: str) -> bool:
+    return bool(_DECIMAL_RE.search(text))
+
+def parse_dates(text: str, birth: date):
+    """Parse ages or explicit dates from user input.
+
+    Parameters
+    ----------
+    text: str
+        User provided message.
+    birth: date
+        Birth date to convert ages into real dates.
+
+    Returns
+    -------
+    date | tuple[date, date]
+        Parsed date or a tuple of two dates.
+
+    Raises
+    ------
+    ValueError
+        If text doesn't contain a valid date specification or contains
+        textual months or fractional ages.
+    """
+
+    if _contains_text_month(text) or _contains_decimal_age(text):
+        raise ValueError('Некорректный формат даты или возраста')
+
+    # first try to parse as ages
+    try:
+        numbers = list(map(int, re.findall(r'\d+', text)))
+        if len(numbers) == 1:
+            return date(birth.year + numbers[0] + ((birth.month, birth.day) > (8, 31)), 1, 1)
+        elif len(numbers) == 2:
+            start, end = sorted(numbers)
+            start = date(birth.year + start + ((birth.month, birth.day) > (8, 31)), 1, 7)
+            end = date(birth.year + end + ((birth.month, birth.day) > (8, 31)), 12, 31)
+            return start, end
+        else:
+            raise ValueError
+    except Exception:
+        pass
+
+    # try to parse explicit dates
+    dates = []
+    for d, m, y in re.findall(r'\b(\d{1,2})\.(\d{1,2})\.(\d{2,4})\b', text):
+        year = int(y)
+        if year < 100:
+            year += 2000 if year < 50 else 1900
+        try:
+            dates.append(date(year, int(m), int(d)))
+        except ValueError:
+            continue
+
+    if not dates or len(dates) > 2:
+        raise ValueError('Не найдено ни одной корректной даты')
+
+    return tuple(dates) if len(dates) == 2 else dates[0]
+


### PR DESCRIPTION
## Summary
- add `utils/dateparser` module
- reuse date parser in `handle_calendar` and `handle_start`
- check for textual months and decimal ages

## Testing
- `python -m py_compile handlers/handle_calendar.py handlers/handle_start.py utils/dateparser.py`

------
https://chatgpt.com/codex/tasks/task_e_6880aa8c9120833096a0c3300b202a64