### PR TITLE
Parse month names with year

### DIFF
--- a/handlers/handle_start.py
+++ b/handlers/handle_start.py
@@ -6,6 +6,7 @@ from dotenv import load_dotenv
 from utils.typing import _keep_typing
 from life_calendar import create_calendar
 import asyncio, random, os, secrets, re, warnings
+from utils.dateparser import parse_dates
 from utils.dbtools import set_birth, set_name, set_gender, get_user_data, set_empty_event, get_events, set_event, user_exists, delete_data
 warnings.filterwarnings('ignore')
 load_dotenv()
@@ -310,34 +311,20 @@ async def create_second_calendar(update: Update, context: ContextTypes.DEFAULT_T
                     parse_mode   = 'Markdown', 
                 ) 
                 return ASK_DATE
-    else: 
-        if event_type == 'Курение': 
-            try: 
-                dates = list(map(int, re.findall(r'\d+', answer)))
-            except: 
-                await context.bot.send_message(
-                    chat_id      = update.effective_chat.id,
-                    text         = 'Не могу прочитать твой текст😔 Напиши возраст еще раз, в формате «С 16 лет» или «С 16 до 23 лет»', 
-                    parse_mode   = 'Markdown', 
-                )
-                return ASK_DATE
-        else: 
-            try: 
-                dates = list(map(int, re.findall(r'\d+', answer)))
-            except: 
-                await context.bot.send_message(
-                    chat_id      = update.effective_chat.id,
-                    text         = 'Не могу прочитать твой текст😔 Напиши возраст еще раз, в формате «С 16 лет» или «С 16 до 49 лет»', 
-                    parse_mode   = 'Markdown', 
-                )
-                return ASK_DATE
-        if len(dates) == 1: 
-            event = date(year + dates[0] + ((month, day) > (8, 31)), 1, 1)
-        else: 
-            start, end = sorted(dates)
-            start = date(year + start + ((month, day) > (8, 31)), 1, 7)
-            end   = date(year + end + ((month, day) > (8, 31)), 12, 31)
-            event = (start, end)
+    else:
+        try:
+            event = parse_dates(answer, date(year, month, day))
+        except ValueError:
+            if event_type == 'Курение':
+                text_error = 'Не могу прочитать твой текст😔 Напиши возраст еще раз, в формате «С 16 лет» или «С 16 до 23 лет»'
+            else:
+                text_error = 'Не могу прочитать твой текст😔 Напиши возраст еще раз, в формате «С 16 лет» или «С 16 до 49 лет»'
+            await context.bot.send_message(
+                chat_id      = update.effective_chat.id,
+                text         = text_error,
+                parse_mode   = 'Markdown',
+            )
+            return ASK_DATE
 
     await set_event(update.effective_user.id, event_type, event)
     

--- a/utils/dateparser.py
+++ b/utils/dateparser.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import re
+from datetime import date
+
+# map various month name forms to their number
+_MONTH_ALIASES = {
+    'jan': 1, 'january': 1,
+    'feb': 2, 'february': 2,
+    'mar': 3, 'march': 3,
+    'apr': 4, 'april': 4,
+    'may': 5,
+    'jun': 6, 'june': 6,
+    'jul': 7, 'july': 7,
+    'aug': 8, 'august': 8,
+    'sep': 9, 'sept': 9, 'september': 9,
+    'oct': 10, 'october': 10,
+    'nov': 11, 'november': 11,
+    'dec': 12, 'december': 12,
+
+    'янв': 1, 'январь': 1, 'января': 1,
+    'фев': 2, 'февраль': 2, 'февраля': 2,
+    'мар': 3, 'март': 3, 'марта': 3,
+    'апр': 4, 'апрель': 4, 'апреля': 4,
+    'май': 5, 'мая': 5,
+    'июн': 6, 'июнь': 6, 'июня': 6,
+    'июл': 7, 'июль': 7, 'июля': 7,
+    'авг': 8, 'август': 8, 'августа': 8,
+    'сен': 9, 'сент': 9, 'сентябрь': 9, 'сентября': 9,
+    'окт': 10, 'октябрь': 10, 'октября': 10,
+    'ноя': 11, 'ноябрь': 11, 'ноября': 11,
+    'дек': 12, 'декабрь': 12, 'декабря': 12,
+}
+
+_MONTH_WORDS = list(_MONTH_ALIASES.keys())
+
+_MONTH_RE = re.compile('|'.join(re.escape(m) for m in _MONTH_WORDS), re.IGNORECASE)
+_DECIMAL_RE = re.compile(r'\b\d+\.\d+(?!\.)')
+
+_MONTH_TEXT_DATE_RE = re.compile(
+    r'(?:\b(\d{1,2})\s+)?(' + '|'.join(re.escape(m) for m in sorted(_MONTH_WORDS, key=len, reverse=True)) + r')\s+(\d{2,4})',
+    re.IGNORECASE
+)
+
+__all__ = ['parse_dates']
+
+def _contains_decimal_age(text: str) -> bool:
+    return bool(_DECIMAL_RE.search(text))
+
+def _parse_month_text(text: str):
+    """Parse textual months with years from text."""
+    dates = []
+    for day, month_word, year in _MONTH_TEXT_DATE_RE.findall(text):
+        key = month_word.lower().replace('ё', 'е')
+        key = key[:3] if key[:3] in _MONTH_ALIASES else key
+        month = _MONTH_ALIASES.get(key)
+        if not month:
+            continue
+        year = int(year)
+        if year < 100:
+            year += 2000 if year < 50 else 1900
+        d = int(day) if day else 1
+        try:
+            dates.append(date(year, month, d))
+        except ValueError:
+            continue
+    return dates
+
+def parse_dates(text: str, birth: date):
+    """Parse ages or explicit dates from user input.
+
+    Parameters
+    ----------
+    text: str
+        User provided message.
+    birth: date
+        Birth date to convert ages into real dates.
+
+    Returns
+    -------
+    date | tuple[date, date]
+        Parsed date or a tuple of two dates.
+
+    Raises
+    ------
+    ValueError
+        If text doesn't contain a valid date specification or contains
+        textual months or fractional ages.
+    """
+
+    if _contains_decimal_age(text):
+        raise ValueError('Некорректный формат даты или возраста')
+
+    # try to parse numeric explicit dates first
+    dates = []
+    for d, m, y in re.findall(r'\b(\d{1,2})\.(\d{1,2})\.(\d{2,4})\b', text):
+        year = int(y)
+        if year < 100:
+            year += 2000 if year < 50 else 1900
+        try:
+            dates.append(date(year, int(m), int(d)))
+        except ValueError:
+            continue
+
+    if not dates:
+        # then try textual month patterns
+        dates = _parse_month_text(text)
+
+    if not dates:
+        # finally try to parse as ages
+        try:
+            numbers = list(map(int, re.findall(r'\d+', text)))
+            if len(numbers) == 1:
+                return date(
+                    birth.year + numbers[0] + ((birth.month, birth.day) > (8, 31)),
+                    1,
+                    1,
+                )
+            elif len(numbers) == 2:
+                start, end = sorted(numbers)
+                start = date(
+                    birth.year + start + ((birth.month, birth.day) > (8, 31)),
+                    1,
+                    7,
+                )
+                end = date(
+                    birth.year + end + ((birth.month, birth.day) > (8, 31)),
+                    12,
+                    31,
+                )
+                return start, end
+        except Exception:
+            pass
+
+    if not dates or len(dates) > 2:
+        raise ValueError('Не найдено ни одной корректной даты')
+
+    return tuple(dates) if len(dates) == 2 else dates[0]
+


### PR DESCRIPTION
## Summary
- extend date parser with Russian and English month words
- parse month+year expressions like "May 2025"

## Testing
- `python -m py_compile handlers/handle_calendar.py handlers/handle_start.py utils/dateparser.py`

------
https://chatgpt.com/codex/tasks/task_e_6880aa8c9120833096a0c3300b202a64