### PR TITLE
Add /community handler docstring

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -4,6 +4,7 @@ from handlers.handle_start import ASK_BIRTHDAY, ASK, ASK_NAME, ASK_GENDER, ASK_T
 from handlers.handle_start import handle_start, ask, ask_name, ask_gender, ask_type, ask_dates, create_second_calendar, clean_data, ask_more
 from handlers.handle_oblivion import DELETE_ACCOUNT, handle_oblivion, oblivion_answer
 from handlers.handle_help import handle_help
+from handlers.handle_community import handle_community
 from handlers.handle_me import (
     ME_ACTION, ME_NAME, ME_BIRTHDAY, ME_GENDER,
     handle_me, me_option, change_name, change_birthday, change_gender,
@@ -105,6 +106,7 @@ def main():
     application.add_handler(calendar_conversation)
     application.add_handler(me_conversation)
     application.add_handler(oblivion_conversation)
+    application.add_handler(CommandHandler('community', handle_community))
     application.add_handler(CommandHandler('help', handle_help))
     # Изменить свои данные можно командой /me
     application.run_polling()

--- a/handlers/handle_community.py
+++ b/handlers/handle_community.py
@@ -1,0 +1,45 @@
+import asyncio
+import os
+import warnings
+from datetime import datetime, timedelta
+
+from dotenv import load_dotenv
+from telegram import Update
+from telegram.ext import ContextTypes
+from utils.typing import _keep_typing
+
+warnings.filterwarnings('ignore')
+load_dotenv()
+
+COMMUNITY_URL = os.getenv('COMMUNITY_URL')
+
+"""Telegram community chat helper.
+
+Set ``COMMUNITY_URL`` in your environment (e.g. in a ``.env`` file) to the
+@username of your community chat or to a permanent invite link. The handler
+tries to create a new invite link valid for two minutes. If it fails, the
+stored ``COMMUNITY_URL`` is sent instead.
+"""
+
+async def handle_community(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    stop_event  = asyncio.Event()
+    typing_task = context.application.create_task(
+        _keep_typing(update.effective_chat.id, context.bot, stop_event)
+    )
+
+    try:
+        invite = await context.bot.create_chat_invite_link(
+            chat_id     = COMMUNITY_URL,
+            expire_date = datetime.utcnow() + timedelta(minutes = 2)
+        )
+        link = invite.invite_link
+    except Exception:
+        link = COMMUNITY_URL
+
+    stop_event.set()
+    await typing_task
+    await context.bot.send_message(
+        chat_id    = update.effective_chat.id,
+        text       = f'Вот ссылка на наш чат: {link}',
+        parse_mode = 'Markdown',
+    )


### PR DESCRIPTION
## Summary
- remove Community section from README
- explain how to supply the chat URL in `handle_community`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688246c11df48330864a3be90457424a