### PR TITLE
Fix database defaults

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,11 @@ services:
       - .env
     environment:
       LIFE_BOT_TOKEN: ${TELEGRAM_TOKEN}
-      DATABASE_URL: ${DATABASE_URL}
-      DATABASE_PORT: ${DATABASE_PORT}
-      DATABASE_USER: ${DATABASE_USER}
-      DATABASE_PASSWORD: ${DATABASE_PASSWORD}
+      DATABASE_URL: ${DATABASE_URL:-db}
+      DATABASE_PORT: ${DATABASE_PORT:-5432}
+      DATABASE_USER: ${DATABASE_USER:-postgres}
+      DATABASE_PASSWORD: ${DATABASE_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-life}
       COMMUNITY_ID: ${COMMUNITY_URL}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY}
     restart: always
@@ -23,9 +24,9 @@ services:
     volumes:
       - db-data:/var/lib/postgresql/data
     environment:
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-life}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     ports:
       - "5432:5432"
 

--- a/utils/dbtools.py
+++ b/utils/dbtools.py
@@ -5,7 +5,18 @@ from security import encryption
 from datetime import date, datetime
 load_dotenv()
 
-DATABASE_URL = os.getenv('DATABASE_URL')
+# Build a PostgreSQL DSN from individual environment variables.
+# DATABASE_URL is treated as the host name. Other connection
+# parameters have sane defaults so the bot can run without a
+# separate .env file.
+DB_HOST     = os.getenv('DATABASE_URL', 'db')
+DB_PORT     = os.getenv('DATABASE_PORT', '5432')
+DB_USER     = os.getenv('DATABASE_USER', 'postgres')
+DB_PASSWORD = os.getenv('DATABASE_PASSWORD', 'postgres')
+DB_NAME     = os.getenv('POSTGRES_DB', 'life')
+
+# Final DSN used by asyncpg
+DATABASE_URL = f'postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}'
 _pool: asyncpg.Pool | None = None
 
 async def init_pool(min_size: int = 5, max_size: int = 20):


### PR DESCRIPTION
## Summary
- configure docker compose to create a `life` PostgreSQL database by default
- compute a proper PostgreSQL DSN in `dbtools`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883636bbf5c8330b75b87939299afc2