### PR TITLE
Add lifestyle questionnaire

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,12 @@
 from handlers.handle_calendar import ACTION_TYPE, EVENT_NAME_POLL, EVENT_NAME_TEXT
 from handlers.handle_calendar import handle_calendar, user_action, add_new_event, action
-from handlers.handle_start import ASK_BIRTHDAY, ASK, ASK_NAME, ASK_GENDER, ASK_TYPE, ASK_DATE, ASK_MORE, DELETE_DATA
-from handlers.handle_start import handle_start, ask, ask_name, ask_gender, ask_type, ask_dates, create_second_calendar, clean_data, ask_more
+from handlers.handle_start import (
+    ASK_BIRTHDAY, ASK, ASK_NAME, ASK_GENDER, ASK_TYPE, ASK_DATE, ASK_MORE,
+    HABIT_INTRO, HABIT_Q, DELETE_DATA,
+    handle_start, ask, ask_name, ask_gender, ask_type, ask_dates,
+    create_second_calendar, clean_data, ask_more
+)
+from handlers.habits import ask_habits_intro, habits_intro_answer, habits_question_answer
 from handlers.handle_oblivion import DELETE_ACCOUNT, handle_oblivion, oblivion_answer
 from handlers.handle_community import handle_community, gatekeeper
 from handlers.handle_help import handle_help
@@ -88,6 +93,8 @@ def main():
             ASK_TYPE     : [CallbackQueryHandler(ask_dates)],
             ASK_DATE     : [MessageHandler(filters.TEXT & ~filters.COMMAND, create_second_calendar)],
             ASK_MORE     : [CallbackQueryHandler(ask_more)],
+            HABIT_INTRO : [CallbackQueryHandler(habits_intro_answer)],
+            HABIT_Q     : [CallbackQueryHandler(habits_question_answer)],
         },
         fallbacks = [CommandHandler('cancel', cancel)],
         allow_reentry = True

--- a/handlers/habits.py
+++ b/handlers/habits.py
@@ -1,0 +1,143 @@
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.ext import ContextTypes
+from datetime import date
+import secrets, os
+from utils.life_calendar import create_calendar
+from utils.dbtools import set_expectation, get_user_data
+from utils.typing import keep_typing
+
+HABIT_INTRO, HABIT_Q = range(2)
+
+QUESTIONS = [
+    {
+        'text': 'Ты куришь? Если бросил, жми «Нет».',
+        'options': [('Да', -10), ('Нет', 0)],
+    },
+    {
+        'text': 'Сколько ты спишь?',
+        'options': [
+            ('Меньше 6 часов', -5),
+            ('6–9 часов', 0),
+            ('10 часов и больше', -5),
+        ],
+    },
+    {
+        'text': 'Ешь колбасы, сосиски, бекон и другие переработанные мясные продукты?',
+        'options': [('Да', -5), ('Нет', 0)],
+    },
+    {
+        'text': 'Занимаешься спортом?',
+        'options': [('Нет', -3), ('Редко', 0), ('2 раза в неделю и чаще', 6)],
+    },
+    {
+        'text': 'Ешь сахар? Сюда относится газировка и сладости чаще раза в месяц.',
+        'options': [('Да', 0), ('Нет', 5)],
+    },
+    {
+        'text': 'Пьешь алкоголь? Считается даже раз в месяц или по праздникам.',
+        'options': [('Да', -2), ('Нет', 7)],
+    },
+    {
+        'text': 'Следишь за рационом: больше белка, клетчатки, орехи, мало сахара?',
+        'options': [('Да', 5), ('Нет', 0)],
+    },
+    {
+        'text': 'Какого цвета на карте качества воздуха город, в котором ты живешь больше всего?',
+        'options': [
+            ('Синий или зеленый', 2),
+            ('Желтый', 0),
+            ('Красный', -3),
+        ],
+    },
+]
+
+@keep_typing
+async def ask_habits_intro(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    keyboard = [[
+        InlineKeyboardButton('Да', callback_data='yes'),
+        InlineKeyboardButton('Нет', callback_data='no')
+    ]]
+    await context.bot.send_message(
+        chat_id=update.effective_chat.id,
+        text='Хочешь пройти небольшой опрос из 8 вопросов? Он поможет узнать, сколько клеточек в твоем календаре.',
+        reply_markup=InlineKeyboardMarkup(keyboard),
+        parse_mode='Markdown'
+    )
+    return HABIT_INTRO
+
+@keep_typing
+async def habits_intro_answer(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    await query.answer()
+    answer = query.data
+    await context.bot.delete_message(chat_id=query.message.chat.id, message_id=query.message.message_id)
+    if answer == 'yes':
+        context.user_data['habit_idx'] = 0
+        context.user_data['delta'] = 0
+        return await _ask_next_question(update, context)
+    else:
+        from handlers.handle_start import finish_start
+        return await finish_start(update, context)
+
+async def _ask_next_question(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    idx = context.user_data.get('habit_idx', 0)
+    if idx >= len(QUESTIONS):
+        return await _finish_questions(update, context)
+    q = QUESTIONS[idx]
+    keyboard = [[InlineKeyboardButton(opt[0], callback_data=str(i)) for i, opt in enumerate(q['options'])]]
+    if len(q['options']) > 2:
+        keyboard = [
+            [InlineKeyboardButton(q['options'][0][0], callback_data='0')],
+            [InlineKeyboardButton(q['options'][1][0], callback_data='1')],
+            [InlineKeyboardButton(q['options'][2][0], callback_data='2')],
+        ]
+    await context.bot.send_message(
+        chat_id=update.effective_chat.id,
+        text=q['text'],
+        reply_markup=InlineKeyboardMarkup(keyboard),
+        parse_mode='Markdown'
+    )
+    return HABIT_Q
+
+@keep_typing
+async def habits_question_answer(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    await query.answer()
+    idx = context.user_data.get('habit_idx', 0)
+    q = QUESTIONS[idx]
+    choice = int(query.data)
+    context.user_data['delta'] = context.user_data.get('delta', 0) + q['options'][choice][1]
+    context.user_data['habit_idx'] = idx + 1
+    await context.bot.delete_message(chat_id=query.message.chat.id, message_id=query.message.message_id)
+    if context.user_data['habit_idx'] < len(QUESTIONS):
+        return await _ask_next_question(update, context)
+    else:
+        return await _finish_questions(update, context)
+
+async def _finish_questions(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    delta = context.user_data.get('delta', 0)
+    user = await get_user_data(update.effective_user.id)
+    gender = user.get('gender', 'male')
+    base = 81 if gender == 'female' else 71
+    expectation = max(55, base + delta)
+    await set_expectation(update.effective_user.id, expectation)
+    day, month, year = map(int, user['birth'].split('.'))
+    birth = date(year, month, day)
+    filename = f'tmp/{secrets.token_hex(8)}.png'
+    create_calendar(birth, fname=filename, female=(gender=='female'), expectation=expectation)
+    with open(filename, 'rb') as photo:
+        await context.bot.send_document(
+            chat_id=update.effective_chat.id,
+            document=photo,
+            caption='Вот твой календарь с учетом твоего стиля жизни',
+            parse_mode='Markdown'
+        )
+    os.remove(filename)
+    sign = '+' if expectation - base >= 0 else ''
+    await context.bot.send_message(
+        chat_id=update.effective_chat.id,
+        text=f'Твоя ожидаемая продолжительность жизни изменилась на {sign}{expectation - base} лет.',
+        parse_mode='Markdown'
+    )
+    from handlers.handle_start import finish_start
+    return await finish_start(update, context)

--- a/handlers/handle_start.py
+++ b/handlers/handle_start.py
@@ -7,13 +7,20 @@ from utils.typing import keep_typing
 from utils.dateparser import parse_dates
 from utils.life_calendar import create_calendar
 import asyncio, random, os, secrets, re, warnings
-from utils.dbtools import set_birth, set_name, set_gender, get_user_data, set_empty_event, set_event, user_exists, delete_data
+from utils.dbtools import (
+    set_birth, set_name, set_gender, get_user_data,
+    set_empty_event, set_event, user_exists, delete_data
+)
+from handlers.habits import (
+    HABIT_INTRO, HABIT_Q,
+    ask_habits_intro, habits_intro_answer, habits_question_answer
+)
 warnings.filterwarnings('ignore')
 load_dotenv()
 
 # ———————————————————————————————————————— START HANDLERS ————————————————————————————————————————
 
-ASK_BIRTHDAY, ASK, ASK_NAME, ASK_GENDER, ASK_TYPE, ASK_DATE, ASK_MORE, DELETE_DATA = range(8)
+ASK_BIRTHDAY, ASK, ASK_NAME, ASK_GENDER, ASK_TYPE, ASK_DATE, ASK_MORE, HABIT_INTRO, HABIT_Q, DELETE_DATA = range(10)
 
 @keep_typing
 async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -217,7 +224,7 @@ async def ask_event(update: Update, context: ContextTypes.DEFAULT_TYPE):
         )
         return ASK_TYPE
     else:
-        return await finish_start(update, context)
+        return await ask_habits_intro(update, context)
 
 @keep_typing
 async def ask_dates(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -226,7 +233,7 @@ async def ask_dates(update: Update, context: ContextTypes.DEFAULT_TYPE):
     answer = query.data
     if answer == 'finish':
         await context.bot.delete_message(chat_id = query.message.chat.id, message_id = query.message.message_id)
-        return await finish_start(update, context)
+        return await ask_habits_intro(update, context)
     user_data = await get_user_data(update.effective_user.id)
     gender = user_data.get('gender')
     if not gender:
@@ -370,7 +377,7 @@ async def ask_more(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if answer == 'more_yes':
         return await ask_event(update, context)
     else:
-        return await finish_start(update, context)
+        return await ask_habits_intro(update, context)
 
 @keep_typing
 async def finish_start(update: Update, context: ContextTypes.DEFAULT_TYPE):

--- a/utils/dbtools.py
+++ b/utils/dbtools.py
@@ -234,8 +234,23 @@ async def delete_data(user_id: int):
     async with pool.acquire() as conn:
         await conn.execute('UPDATE users SET name = NULL, birth = NULL, gender = NULL, data = NULL WHERE id = $1;', user_id)
 
+async def set_expectation(user_id: int, value: int):
+    if value < 55:
+        value = 55
+    pool = await get_database_pool()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            'INSERT INTO users(id, expectation) VALUES($1, $2) ON CONFLICT (id) DO UPDATE SET expectation = EXCLUDED.expectation;',
+            user_id, value
+        )
+
+async def get_expectation(user_id: int) -> int | None:
+    pool = await get_database_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow('SELECT expectation FROM users WHERE id = $1;', user_id)
+        return row['expectation'] if row else None
+
 async def delete_user(user_id: int):
     pool = await get_database_pool()
     async with pool.acquire() as conn:
         await conn.execute('DELETE FROM users WHERE id = $1;', user_id)
-    

--- a/utils/life_calendar.py
+++ b/utils/life_calendar.py
@@ -22,7 +22,7 @@ BLACK_FONT =    {'family': 'Montserrat', 'weight': 'black',   'size': plt.rcPara
 BOLD_FONT =     {'family': 'Montserrat', 'weight': 'bold',    'size': plt.rcParams.get('font.size', 12) * 0.6}
 TEXT_FONT =     {'family': 'Montserrat', 'weight': 'regular', 'size': plt.rcParams.get('font.size', 12) * 0.6}
 
-def create_calendar(birthday, fname, female = True, h = 13, w = 9, transparent = False, event = None, label = None):
+def create_calendar(birthday, fname, female = True, h = 13, w = 9, transparent = False, event = None, label = None, expectation = None):
     plt.rcParams.update(plt.rcParamsDefault)
     _, ax = plt.subplots(figsize = (w, h))
     ax.set_axis_off()
@@ -41,10 +41,11 @@ def create_calendar(birthday, fname, female = True, h = 13, w = 9, transparent =
     life_weeks = (date.today() - birthday).days // 7 
 
     weeks = np.linspace(0, h, 52)
-    if female: 
-        years = np.linspace(w, 0, 81)
-    else: 
-        years = np.linspace(w, 0, 71)
+    if expectation is None:
+        exp_years = 80 if female else 70
+    else:
+        exp_years = expectation
+    years = np.linspace(w, 0, exp_years + 1)
 
     for year in years:
         for week in weeks:


### PR DESCRIPTION
## Summary
- add new expectation calculator questionnaire to start flow
- compute life expectancy changes and update database
- extend calendar generator with variable life expectancy
- store expectation in database

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a798630c8330a1f0e37f114894ce