### PR TITLE
feat: switch to node-based calendar

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ __pycache__/
 .vscode/
 build/
 dist/
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tmp/
 *.pyc
 .env
 .DS_Store
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,17 @@ RUN addgroup --system app && adduser --system --ingroup app app
 
 WORKDIR /app
 
-# Install Python dependencies
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# Install system dependencies for Node canvas
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    nodejs npm \
+    build-essential gyp libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev librsvg2-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python and Node dependencies
+COPY requirements.txt package.json ./
+RUN pip install --no-cache-dir -r requirements.txt && \
+    npm install --omit=dev && \
+    rm -rf /root/.npm
 
 # Copy application files
 COPY . .

--- a/calendar/life_calendar.mjs
+++ b/calendar/life_calendar.mjs
@@ -24,7 +24,7 @@ const COLORS = {
 const TMP_DIR = path.resolve('../tmp');
 if (!fs.existsSync(TMP_DIR)) fs.mkdirSync(TMP_DIR, { recursive: true });
 
-function createCalendar (birthday, opts = {}) {
+export function createCalendar (birthday, opts = {}) {
   const {
     lifeExpectancy = 80,
     event          = null,

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "life-calendar",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "canvas": "^2.11.2"
+  }
+}
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+

--- a/utils/life_calendar.py
+++ b/utils/life_calendar.py
@@ -1,130 +1,67 @@
+"""Bridge to the Node-based life calendar generator."""
+
 from __future__ import annotations
 
-import numpy as np
-from PIL import Image
-import secrets, warnings
 from datetime import date
-warnings.filterwarnings('ignore')
+from pathlib import Path
+import json
+import subprocess
+from typing import Optional, Tuple, Union
 
-from matplotlib.font_manager import fontManager
-from matplotlib.patches import FancyArrowPatch
-import matplotlib.pyplot as plt
 
-fontManager.addfont('fonts/Montserrat-Bold.ttf')
-fontManager.addfont('fonts/Montserrat-Black.ttf')
-fontManager.addfont('fonts/Montserrat-Regular.ttf')
-plt.rcParams['font.family'] = 'Montserrat'
-plt.rcParams['font.weight'] = 'regular'
+ROOT = Path(__file__).resolve().parents[1]
+CALENDAR_DIR = ROOT / "calendar"
 
-TITLE_FONT =    {'family': 'Montserrat', 'weight': 'black',   'size': plt.rcParams.get('font.size', 12) * 4.4}
-SUBTITLE_FONT = {'family': 'Montserrat', 'weight': 'black',   'size': plt.rcParams.get('font.size', 12) * 1.115}
-BLACK_FONT =    {'family': 'Montserrat', 'weight': 'black',   'size': plt.rcParams.get('font.size', 12) * 0.6}
-BOLD_FONT =     {'family': 'Montserrat', 'weight': 'bold',    'size': plt.rcParams.get('font.size', 12) * 0.6}
-TEXT_FONT =     {'family': 'Montserrat', 'weight': 'regular', 'size': plt.rcParams.get('font.size', 12) * 0.6}
 
-def create_calendar(birthday, fname, female = True, h = 13, w = 9, transparent = False, event = None, label = None):
-    plt.rcParams.update(plt.rcParamsDefault)
-    _, ax = plt.subplots(figsize = (w, h))
-    ax.set_axis_off()
+def create_calendar(
+    birthday: date,
+    fname: str,
+    female: bool = True,
+    transparent: bool = False,
+    event: Union[Tuple[date, date], date, None] = None,
+    label: Optional[str] = None,
+) -> str:
+    """Render a life calendar image via the Node implementation.
 
+    Args:
+        birthday: User birth date.
+        fname: Output filename.
+        female: Use female life expectancy (80) or male (70).
+        transparent: Whether the background should be transparent.
+        event: A single date or ``(start, end)`` tuple to highlight.
+        label: Optional label for the highlighted event.
+
+    Returns:
+        Path to the generated image file.
+    """
+
+    life_expectancy = 80 if female else 70
+
+    opts: dict[str, object] = {
+        "outfile": str(Path(fname).resolve()),
+        "lifeExpectancy": life_expectancy,
+        "transparent": transparent,
+    }
     if event:
-        try: 
-            start, end = event  
-        except: 
-            start = event 
-            end   = date.today()
-        start_weeks = (date.today() - start).days // 7 
-        end_weeks   = (date.today() - end).days // 7 
+        if isinstance(event, tuple):
+            opts["event"] = [d.isoformat() for d in event]
+        else:
+            opts["event"] = event.isoformat()
+    if label:
+        opts["label"] = label
 
-    week_number = 0
-    X, Y, FC, EC = [], [], [], []
-    life_weeks = (date.today() - birthday).days // 7 
-
-    weeks = np.linspace(0, h, 52)
-    exp_years = 80 if female else 70
-    years = np.linspace(w, 0, exp_years + 1)
-
-    for year in years:
-        for week in weeks:
-            week_number += 1
-            X.append(week)
-            Y.append(year)
-            
-            if not event: 
-                if week_number <= life_weeks: 
-                    facecolor = '#D0783B' 
-                    edgecolor = '#D0783B' 
-                else: 
-                    facecolor = '#FFFFFF' 
-                    edgecolor = '#b0b7d0' 
-            else:
-                if week_number <= life_weeks:
-                    facecolor = "#D0783B"
-                    edgecolor = '#D0783B' 
-                else:
-                    facecolor = '#FFFFFF'
-                    edgecolor = '#b0b7d0'
-
-                in_event = (life_weeks - start_weeks) <= week_number <= (life_weeks - end_weeks)
-
-                if in_event:
-                    edgecolor = '#EECE7B'
-                    if week_number <= life_weeks:
-                        facecolor = '#EECE7B'
-
-            FC.append(facecolor)
-            EC.append(edgecolor)
-
-    ax.scatter(X, Y, facecolors = FC, edgecolors = EC)
-
-    if event: 
-        yellow = [
-            y for y, fc, ec in zip(Y, FC, EC)
-            if fc.lower() == '#eece7b' or ec.lower() == '#eece7b'
-        ]
-        y = np.mean(yellow)
-        plt.text(13.4, y, label, ha = 'center', va = 'center', **BLACK_FONT, rotation = 270, color = '#EECE7B') 
-
-    color = "#120C0B"
-    plt.text(6.3, 10,  'Календарь жизни', ha = 'center', va = 'center', **TITLE_FONT, color = color) 
-    plt.text(6.3, 9.6, 'Время на Земле ограничено и очень важно. На что ты его потратишь?', ha = 'center', va = 'center', **SUBTITLE_FONT, color = color)
-
-    arrow = FancyArrowPatch(
-        posA = (-0.95, 9.07), posB = (-0.95, 8.4),
-        arrowstyle = '-|>', connectionstyle = 'arc3, rad = 0',
-        mutation_scale = 10, linewidth = 1,
-        color = color, capstyle = 'round'
+    js = (
+        "import { createCalendar } from './life_calendar.mjs';"
+        f"const birthday = new Date('{birthday.isoformat()}');"
+        f"const opts = {json.dumps(opts)};"
+        "createCalendar(birthday, opts);"
     )
-    plt.gca().add_patch(arrow)
-    plt.text(-0.8, 8.63, 'ВОЗРАСТ', ha = 'center', **BOLD_FONT, rotation = 270, color = color) 
 
-    arrow = FancyArrowPatch(
-        posA = (-0.12, 9.18), posB = (3.5, 9.18),
-        arrowstyle = '-|>', connectionstyle = 'arc3, rad = 0',
-        mutation_scale = 10, linewidth = 1,
-        color = color, capstyle = 'round'
+    subprocess.run(
+        ["node", "--input-type=module", "-e", js],
+        cwd=CALENDAR_DIR,
+        check=True,
     )
-    plt.gca().add_patch(arrow)
-    plt.text(0.8, 9.23, 'НЕДЕЛИ В ГОДУ', ha = 'center', **BOLD_FONT, color = color) 
 
-    for i, year in enumerate(years):
-        if (i) % 10 == 0 or i == 0:
-            ax.text(-0.4, year, f'{i}', horizontalalignment = 'center', verticalalignment = 'center', **BOLD_FONT, color = color)
-        else: 
-            ax.text(-0.4, year, f'{i}', horizontalalignment = 'center', verticalalignment = 'center', **TEXT_FONT, color = color)
+    return fname
 
-    plt.savefig(fname, dpi = 600, transparent = transparent)
-    img = Image.open(fname)
-    cropped = img.crop((700, 350, img.width - 440, img.height - 1000))
-    cropped.save(fname, dpi = (600, 600))
-
-if __name__ == '__main__':
-    birthday = date(2004, 1, 19)
-    filename = f'tmp/{secrets.token_hex(8)}.png'
-    event = (date(2016, 1, 7), date(2016, 12, 31))
-    label = 'Школа' 
-    transparent = False
-    female = True 
-    expectation = 100
-    
-    create_calendar(birthday, fname = filename, female = female, transparent = transparent, event = event, label = label)


### PR DESCRIPTION
## Summary
- use JS life calendar generator
- expose Python wrapper that runs the Node script
- install Node & canvas deps in Docker image
- include gyp and use `npm install --omit=dev`

## Testing
- `pytest tests/test_dateparser.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688b940801a083309cc62e416d1e2a0b