### PR TITLE
Add logging across bot and handlers

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -18,18 +18,21 @@ from utils.dbtools import init_pool, close_pool
 from datetime import datetime, timezone
 from functools import partial
 
-import telegram 
+import telegram
 from telegram import Update
 from telegram.request import HTTPXRequest
 from telegram.ext import (
-    ApplicationBuilder, MessageHandler, CommandHandler, filters, ContextTypes, 
+    ApplicationBuilder, MessageHandler, CommandHandler, filters, ContextTypes,
     ConversationHandler, CallbackQueryHandler, ChatJoinRequestHandler
 )
 
-import os, warnings
+import os, warnings, logging
 from dotenv import load_dotenv
 warnings.filterwarnings('ignore')
 load_dotenv()
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 LIFE_BOT_TOKEN = os.getenv('LIFE_BOT_TOKEN')
 request = HTTPXRequest(
@@ -62,15 +65,17 @@ store = InviteStore()
 # ———————————————————————————————————————— INITIALIZING BOT ————————————————————————————————————————
 
 async def cancel(update: Update, context: ContextTypes. DEFAULT_TYPE):
+    logger.info('Conversation cancelled for user %s', update.effective_user.username)
     await update.message.reply_text('Хорошо, если передумаешь — я всегда тут')
     return ConversationHandler.END
 
 async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE):
     if isinstance(context.error, telegram.error.Forbidden):
         return
-    print(f'Unhandled error: {context.error}')
+    logger.error('Unhandled error: %s', context.error)
 
 def main():
+    logger.info('Starting bot')
     application = (
         ApplicationBuilder()
         .token(LIFE_BOT_TOKEN)
@@ -80,7 +85,7 @@ def main():
         .build()
     )
     application.add_error_handler(error_handler)
-    print('✅ The bot has successfully launched and is working while you are drinking tea.')
+    logger.info('✅ The bot has successfully launched and is working while you are drinking tea.')
 
     start_conversation = ConversationHandler(
         entry_points = [CommandHandler('start', handle_start)],

--- a/calendar/life_calendar.mjs
+++ b/calendar/life_calendar.mjs
@@ -3,6 +3,8 @@ import crypto from 'crypto';
 import path from 'path';
 import fs from 'fs';
 
+const logger = console;
+
 const FONT_PATH = path.resolve('../fonts');
 registerFont(path.join(FONT_PATH, 'Montserrat-Bold.ttf'   ), { family: 'Montserrat', weight: '900'});
 registerFont(path.join(FONT_PATH, 'Montserrat-Black.ttf'  ), { family: 'Montserrat', weight: '700'});
@@ -32,6 +34,8 @@ export function createCalendar (birthday, opts = {}) {
     transparent    = false,
     outfile        = path.join(TMP_DIR, `${crypto.randomBytes(8).toString('hex')}.png`)
   } = opts;
+
+  logger.info('Creating calendar');
 
   const canvasH = PADDING_TOP + PADDING_BOTTOM + (lifeExpectancy + 1) * ROW_HEIGHT;
   const canvas  = createCanvas(CANVAS_W, canvasH);
@@ -145,6 +149,7 @@ export function createCalendar (birthday, opts = {}) {
 
   const outStream = fs.createWriteStream(outfile);
   canvas.createPNGStream().pipe(outStream);
+  logger.info(`Calendar saved to ${outfile}`);
   return outfile;
 }
 
@@ -153,4 +158,5 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   const event    = [new Date(2016, 0, 10), new Date(2026, 11, 31)];
   const label    = 'Образование';
   createCalendar(birthday, { lifeExpectancy: 80, event, label });
+  logger.info('Sample calendar generated');
 }

--- a/handlers/handle_community.py
+++ b/handlers/handle_community.py
@@ -1,5 +1,5 @@
 from dotenv import load_dotenv
-import warnings, os, asyncio, random
+import warnings, os, asyncio, random, logging
 from utils.dbtools import user_exists
 from telegram.ext import ContextTypes
 from utils.typing_task import keep_typing
@@ -8,20 +8,20 @@ from datetime import datetime, timedelta, timezone
 warnings.filterwarnings('ignore')
 load_dotenv()
 
+logger = logging.getLogger(__name__)
+
 COMMUNITY_ID = os.getenv('COMMUNITY_ID')
 
 # ———————————————————————————————————————— GATE KEEPER ————————————————————————————————————————
 
 async def gatekeeper(update: Update, context: ContextTypes.DEFAULT_TYPE, store = None):
     req: ChatJoinRequest = update.chat_join_request
-    
-    print(f'👀 I see someone trying to join: {req.invite_link.invite_link}')
+
+    logger.info('Join request from %s', req.from_user.username)
     ok_user = store.pop(req.invite_link.invite_link)
-    print(f'👀 That\'s who it is: {ok_user}') 
-    print(f'That\'s what I\'m waiting for: {req.from_user.id}')
 
     if ok_user == req.from_user.id:
-        print('✅ Accepted')
+        logger.info('Accepted join request for %s', req.from_user.username)
 
         emoji = random.choice(['🌼', '🌸', '🍀', '🌺', '🌳', '🍁', '🌲', '🍃', '🌷', '🌻', '🌱', '🌿', '💮', '🪴', '🌾', '🪻'])
         await context.bot.approve_chat_join_request(COMMUNITY_ID, req.from_user.id)
@@ -31,15 +31,15 @@ async def gatekeeper(update: Update, context: ContextTypes.DEFAULT_TYPE, store =
             parse_mode = 'HTML',
         )
     else:
-        print('❌ Rejected')
+        logger.info('Rejected join request for %s', req.from_user.username)
         await context.bot.decline_chat_join_request(COMMUNITY_ID, req.from_user.id)
 
 # ———————————————————————————————————————— COMMUNITY HANDLER ————————————————————————————————————————
 
 @keep_typing
 async def handle_community(update: Update, context: ContextTypes.DEFAULT_TYPE, store = None):
-    await asyncio.sleep(3) 
-    exist = await user_exists(update.effective_user.id) 
+    await asyncio.sleep(3)
+    exist = await user_exists(update.effective_user.id)
     if not exist:
         await context.bot.send_message(
             chat_id     = update.effective_chat.id,
@@ -56,14 +56,17 @@ async def handle_community(update: Update, context: ContextTypes.DEFAULT_TYPE, s
         link = invite.invite_link
         store.add(link, update.effective_user.id, expires)
 
+        logger.info('Generated invite link for user %s', update.effective_user.username)
         await context.bot.send_message(
             chat_id    = update.effective_chat.id,
             text       = f'Держи [ссылку]({link}) на наше закрытое комьюнити — она действует всего 5 минут (если не успеешь зайти, попроси еще одну — я поделюсь)',
             parse_mode = 'Markdown',
         )
-    except: 
+    except Exception as exc:
+        logger.error('Failed to generate invite link for user %s: %s', update.effective_user.username, exc)
         await context.bot.send_message(
             chat_id    = update.effective_chat.id,
             text       = f'Не получается сгенерировать ссылку :( Обратись в поддержку: мой создатель сам создаст ее специально для тебя',
             parse_mode = 'Markdown',
         )
+

--- a/handlers/handle_help.py
+++ b/handlers/handle_help.py
@@ -3,19 +3,23 @@ from telegram.ext import ContextTypes
 from utils.dbtools import user_exists
 from dotenv import load_dotenv
 from telegram import Update
-import asyncio, warnings
+import asyncio, warnings, logging
 
 warnings.filterwarnings('ignore')
 load_dotenv()
 
+logger = logging.getLogger(__name__)
+
 @keep_typing
 async def handle_help(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    await asyncio.sleep(3) 
-    exist = await user_exists(update.effective_user.id) 
+    await asyncio.sleep(3)
+    logger.info('User %s requested help', update.effective_user.username)
+    exist = await user_exists(update.effective_user.id)
     if not exist:
+        logger.info('User %s is not registered for help command', update.effective_user.username)
         await context.bot.send_message(
             chat_id     = update.effective_chat.id,
-            text        = f'Чтобы использовать эту команду, тебе сначала нужно зарегестрироваться. Для этого нажми на /start', 
+            text        = f'Чтобы использовать эту команду, тебе сначала нужно зарегестрироваться. Для этого нажми на /start',
             parse_mode  = 'Markdown'
         )
     help_text = (

--- a/handlers/handle_oblivion.py
+++ b/handlers/handle_oblivion.py
@@ -5,10 +5,12 @@ from utils.typing_task import keep_typing
 from utils.dbtools import user_exists, get_user_data, delete_user
 
 from dotenv import load_dotenv
-import os, warnings, asyncio
+import os, warnings, asyncio, logging
 
 warnings.filterwarnings('ignore')
 load_dotenv()
+
+logger = logging.getLogger(__name__)
 
 DATABASE_URL       = os.getenv('DATABASE_URL')
 DATABASE_PORT      = os.getenv('DATABASE_PORT')
@@ -19,6 +21,7 @@ DELETE_ACCOUNT = range(1)
 
 @keep_typing
 async def handle_oblivion(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    logger.info('User %s initiated oblivion', update.effective_user.username)
     exist = await user_exists(update.effective_user.id)
     if not exist:
         await context.bot.send_message(
@@ -48,6 +51,7 @@ async def oblivion_answer(update: Update, context: ContextTypes.DEFAULT_TYPE):
     query = update.callback_query
     await query.answer()
     answer = query.data
+    logger.info('User %s answered oblivion prompt', update.effective_user.username)
 
     await context.bot.delete_message(chat_id = query.message.chat.id, message_id = query.message.message_id)
     if answer == 'yes':
@@ -65,3 +69,4 @@ async def oblivion_answer(update: Update, context: ContextTypes.DEFAULT_TYPE):
             parse_mode = 'Markdown'
         )
         return ConversationHandler.END
+


### PR DESCRIPTION
## Summary
- configure centralized logging in bot startup
- add info-level logs throughout handler modules
- emit console logs when generating calendar images
- log only Telegram usernames without personal data

## Testing
- `pytest`
- `cd calendar && node life_calendar.mjs`


------
https://chatgpt.com/codex/tasks/task_e_6894ba435e4883308a32d656e1993220